### PR TITLE
Direct Play info shows incorrect resolution

### DIFF
--- a/source/VideoPlayer.brs
+++ b/source/VideoPlayer.brs
@@ -537,7 +537,8 @@ Function videoPlayerConstructVideoItem(item, options) as Object
 	   end if
 
 	   resolution = ""
-	   if serverStreamInfo.VideoStream <> invalid and serverStreamInfo.VideoStream.Width <> invalid then resolution = tostr(serverStreamInfo.VideoStream.Width) + "p "
+	   ' Change the VideoStream.Width to Height, shows 1920p instead of 1080p and 1280p instead of 720p in Direct Play Info
+	   if serverStreamInfo.VideoStream <> invalid and serverStreamInfo.VideoStream.Height <> invalid then resolution = tostr(serverStreamInfo.VideoStream.Height) + "p "
 
         item.ReleaseDate = releaseDate + "   Direct Play (" + resolution + audioCh + " " + audioCodec + " " + tostr(item.StreamFormat) + ")"
 	else


### PR DESCRIPTION
Direct Play info shows incorrect resolution, shows 1920p instead of 1080p and 1280p instead of 720p in Direct Play Info
