### PR TITLE
Allow roku 3 w/v5.x firmware to set maxrefframes at 12

### DIFF
--- a/source/appMain.brs
+++ b/source/appMain.brs
@@ -124,7 +124,7 @@ Sub initGlobals()
     ' on at least one test video there were noticeable artifacts as the
     ' number increased, starting with 8.
     if left(modelNumber,4) = "4200" and major >=5 then
-	GetGlobalAA().AddReplace("maxRefFrames", 10)
+	GetGlobalAA().AddReplace("maxRefFrames", 12)
     elseif major >= 4 then
         GetGlobalAA().AddReplace("maxRefFrames", 8)
     else


### PR DESCRIPTION
This is a few changes. Adds in the missing roku3 model 4200R which is why some people with roku3 may have said DTS didn't work. I know why and that is fixed. Also the roku3 can easily support a reframe of 12. So added support for that as well. Excuse my rookie mistakes and multiple commits. I'm still learning how this works and editing on the server remotely through this web interface.
