### PR TITLE
Update VideoMetadata.brs

### DIFF
--- a/source/VideoMetadata.brs
+++ b/source/VideoMetadata.brs
@@ -158,16 +158,7 @@ Sub addVideoPlaybackInfo(item, options)
 		url = url + "&profile=high"
 		url = url + "&level=41"
 		url = url + "&deviceId=" + getGlobalVar("rokuUniqueId", "Unknown")
-		
-		url = url + "&ClientTime=" + CreateObject("roDateTime").asSeconds().tostr()
-		url = url + "&MaxVideoBitDepth=8"
-		
-		maxRefFrames = firstOf(getGlobalVar("maxRefFrames"), 0)
-		
-		if maxRefFrames > 0 then
-			url = url + "&MaxRefFrames=" + maxRefFrames.tostr()
-		end if
-		
+
 		url = url + "&AudioCodec=" + streamInfo.AudioCodec
 		url = url + "&MaxAudioChannels=" + tostr(streamInfo.MaxAudioChannels)
 
@@ -510,7 +501,7 @@ Function videoCanDirectPlay(mediaSource, audioStream, videoStream, subtitleStrea
 
         if audioStream <> invalid then
 
-	    debug("Audiochannels: " + tostr(audiostream.channels)
+	    debug("Audiochannels: " + tostr(audiostream.channels))
 
             if surroundSound AND audioStream.codec = "ac3" then
                 'mediaItem.canDirectPlay = true
@@ -578,15 +569,14 @@ Function videoCanDirectPlay(mediaSource, audioStream, videoStream, subtitleStrea
             return false
         end if
 
-        if videoStream <> invalid then
-            if firstOf(videoStream.RefFrames, 0) > firstOf(getGlobalVar("maxRefFrames"), 0) then
-                ' Not only can we not Direct Play, but we want to make sure we
-                ' don't try to Direct Stream.
-                'mediaItem.forceTranscode = true
-                Debug("videoCanDirectPlay: too many ReFrames: " + tostr(videoStream.RefFrames))
-                return false
-            end if
-
+        if videoStream <> invalid and firstOf(videoStream.RefFrames, 0) > firstOf(getGlobalVar("maxRefFrames"), 0) then
+            ' Not only can we not Direct Play, but we want to make sure we
+            ' don't try to Direct Stream.
+            'mediaItem.forceTranscode = true
+            Debug("videoCanDirectPlay: too many ReFrames: " + tostr(videoStream.RefFrames))
+            return false
+        end if
+            
             if firstOf(videoStream.BitDepth, 0) > 8 then
                 'mediaItem.forceTranscode = true
                 Debug("videoCanDirectPlay: bitDepth too high: " + tostr(videoStream.BitDepth))
@@ -596,7 +586,7 @@ Function videoCanDirectPlay(mediaSource, audioStream, videoStream, subtitleStrea
 
         if audioStream <> invalid then
 
-	    debug("Audiochannels: " + tostr(audiostream.channels)
+	    debug("Audiochannels: " + tostr(audiostream.channels))
 
             if surroundSound AND audioStream.codec = "ac3" then
                 'mediaItem.canDirectPlay = true


### PR DESCRIPTION
Sometimes stereoCodec and surroundCodec will return invalid incorrectly. Instead of rely on these use audioStream.codec in their place.
