### PR TITLE
Add Dialog to install beta from within app

### DIFF
--- a/source/ViewController.brs
+++ b/source/ViewController.brs
@@ -1860,7 +1860,7 @@ Sub CheckDisplayBetaHint()
 
     message = message.split("|")
     title = FirstOf(message[0], "Try our fresh new app!")
-    msg = FirstOf(message[1], "Preview the upcoming much improved Emby Roku app now!  A beautifully redesigned interface that allows you to view your Emby content on your Roku like never before.  Try it now by installing the private preview channel at http://emby.media/roku")
+    msg = FirstOf(message[1], "Preview the upcoming much improved Emby Roku app now! Â A beautifully redesigned interface that allows you to view your Emby content on your Roku like never before. Â Try it now by installing the private preview channel at http://emby.media/roku")
     
     port = CreateObject("roMessagePort")
     dialog = CreateObject("roMessageDialog")
@@ -1868,7 +1868,8 @@ Sub CheckDisplayBetaHint()
     dialog.SetTitle(title)
     dialog.AddStaticText(msg)
     
-    dialog.AddButton(1, "OK")
+    dialog.AddButton(1, "Install the app")
+    dialog.AddButton(2, "Cancel")
     dialog.EnableBackButton(false)
     dialog.Show()
 
@@ -1881,8 +1882,11 @@ Sub CheckDisplayBetaHint()
         dlgMsg = wait(0, dialog.GetMessagePort())
         if type(dlgMsg) = "roMessageDialogEvent"
                 if dlgMsg.isButtonPressed()
-                    if dlgMsg.GetIndex() = 1
-                            closeChannel = true
+                    msg = dlgMsg.GetIndex()
+		    if msg = 1
+                            GetNewBeta()
+		    else if msg = 2
+		            closeChannel = true
                     end if
                     exit while
                 else if dlgMsg.isScreenClosed()
@@ -1893,4 +1897,16 @@ Sub CheckDisplayBetaHint()
     dialog.Close()
 
 
+End Sub
+
+Sub GetNewBeta()
+    connection = createObject("roDeviceInfo").GetConnectionInfo()
+    ip = connection.lookup("ip")
+    Debug("Sending message to roku to install emby preview app.")		
+    ' URL
+    url = "http://"+ip+":8060/install/120610"
+    ' Prepare Request
+    request = HttpRequest(url)
+    ' Execute Request
+    response = request.PostFromStringWithTimeout("", 5)
 End Sub

--- a/source/ViewController.brs
+++ b/source/ViewController.brs
@@ -1839,9 +1839,10 @@ Sub CheckDisplayBetaHint()
     lastSeconds = last.AsSeconds()
     
     diff = nowSeconds - lastSeconds
-    
-    If diff < 7 * 24 * 60 * 60 Then
+    Apps = QueryApps()
+    If diff < 7 * 24 * 60 * 60 or AppExists(Apps, "120610") Then
         ' Message has already been displayed during the last 7 days
+	' or App has already been installed. No need to display dialog.
         return
     End If
     
@@ -1910,3 +1911,23 @@ Sub GetNewBeta()
     ' Execute Request
     response = request.PostFromStringWithTimeout("", 5)
 End Sub
+
+Function QueryApps() As String
+	connection = createObject("roDeviceInfo").GetConnectionInfo()
+	ip = connection.lookup("ip")
+	' URL
+	url = "http://"+ip+":8060/query/apps"
+	print url
+	' Prepare Request
+	request = HttpRequest(url)
+	' Execute Request
+	response = request.GetToStringWithTimeout(10)
+	return response
+End Function
+
+Function AppExists(App as String, Id As String) as Boolean
+	regex = "<app id="+chr(34)+Id+chr(34)
+	r = createObject("roRegex",regex,"i")
+	if r.ismatch(App) then return true
+	return false
+End Function

--- a/source/ViewController.brs
+++ b/source/ViewController.brs
@@ -270,8 +270,12 @@ Function vcCreateHomeScreen()
 	screen.refreshBreadcrumb()
 
     screen.Show()
-
-    CheckDisplayBetaHint()
+   
+    ' only display beta dialog for devices 7.5 or higher
+    versionArr = getGlobalVar("rokuVersion")
+    If CheckMinimumVersion(versionArr, [7, 5]) then
+        CheckDisplayBetaHint()
+    end if
     
     return screen
 End Function


### PR DESCRIPTION
This goes one step further than just to announce the new app in a dialog. This also lets the users choose to install the new beta app from within the app with a single press of the OK button. This uses roku ECP control to launch the install process of the new beta directly on roku. This makes it simple for users to install the new app.